### PR TITLE
Add Dim Check

### DIFF
--- a/ICA_AROMA_functions.py
+++ b/ICA_AROMA_functions.py
@@ -161,9 +161,11 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
         pixdim1 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim1 | awk \'{print $2}\'' % (fslDir, inFile)))
         pixdim2 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim2 | awk \'{print $2}\'' % (fslDir, inFile)))
         pixdim3 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim3 | awk \'{print $2}\'' % (fslDir, inFile)))
-
+        dim1 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim1" | awk \'{print $2}\'' % (fslDir, inFile)))
+        dim2 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim2" | awk \'{print $2}\'' % (fslDir, inFile)))
+        dim3 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim3" | awk \'{print $2}\'' % (fslDir, inFile)))
         # If voxel size is not 2mm isotropic, resample the data, otherwise copy the file
-        if (pixdim1 != 2) or (pixdim2 != 2) or (pixdim3 != 2):
+        if (pixdim1 != 2) or (pixdim2 != 2) or (pixdim3 != 2) or (dim1 != 91) or (dim2 != 109) or (dim3 != 91) :
             os.system(' '.join([os.path.join(fslDir, 'flirt'),
                                 ' -ref ' + ref,
                                 ' -in ' + inFile,
@@ -211,7 +213,7 @@ def cross_correlation(a, b):
 
 
 def feature_time_series(melmix, mc):
-    """ This function extracts the maximum RP correlation feature scores. 
+    """ This function extracts the maximum RP correlation feature scores.
     It determines the maximum robust correlation of each component time-series
     with a model of 72 realignment parameters.
 
@@ -342,7 +344,7 @@ def feature_spatial(fslDir, tempDir, aromaDir, melIC):
     ---------------------------------------------------------------------------------
     fslDir:     Full path of the bin-directory of FSL
     tempDir:    Full path of a directory where temporary files can be stored (called 'temp_IC.nii.gz')
-    aromaDir:   Full path of the ICA-AROMA directory, containing the mask-files (mask_edge.nii.gz, mask_csf.nii.gz & mask_out.nii.gz) 
+    aromaDir:   Full path of the ICA-AROMA directory, containing the mask-files (mask_edge.nii.gz, mask_csf.nii.gz & mask_out.nii.gz)
     melIC:      Full path of the nii.gz file containing mixture-modeled threholded (p>0.5) Z-maps, registered to the MNI152 2mm template
 
     Returns
@@ -455,8 +457,8 @@ def feature_spatial(fslDir, tempDir, aromaDir, melIC):
 
 
 def classification(outDir, maxRPcorr, edgeFract, HFC, csfFract):
-    """ This function classifies a set of components into motion and 
-    non-motion components based on four features; 
+    """ This function classifies a set of components into motion and
+    non-motion components based on four features;
     maximum RP correlation, high-frequency content, edge-fraction and CSF-fraction
 
     Parameters
@@ -499,7 +501,7 @@ def classification(outDir, maxRPcorr, edgeFract, HFC, csfFract):
 
     # Put the indices of motion-classified ICs in a text file
     txt = open(os.path.join(outDir, 'classified_motion_ICs.txt'), 'w')
-    if motionICs.size > 1:  # and len(motionICs) != 0: if motionICs is not None and 
+    if motionICs.size > 1:  # and len(motionICs) != 0: if motionICs is not None and
         txt.write(','.join(['{:.0f}'.format(num) for num in (motionICs + 1)]))
     elif motionICs.size == 1:
         txt.write('{:.0f}'.format(motionICs + 1))
@@ -532,7 +534,7 @@ def classification(outDir, maxRPcorr, edgeFract, HFC, csfFract):
 
 
 def denoising(fslDir, inFile, outDir, melmix, denType, denIdx):
-    """ This function classifies the ICs based on the four features; 
+    """ This function classifies the ICs based on the four features;
     maximum RP correlation, high-frequency content, edge-fraction and CSF-fraction
 
     Parameters
@@ -541,7 +543,7 @@ def denoising(fslDir, inFile, outDir, melmix, denType, denIdx):
     inFile:     Full path to the data file (nii.gz) which has to be denoised
     outDir:     Full path of the output directory
     melmix:     Full path of the melodic_mix text file
-    denType:    Type of requested denoising ('aggr': aggressive, 'nonaggr': non-aggressive, 'both': both aggressive and non-aggressive 
+    denType:    Type of requested denoising ('aggr': aggressive, 'nonaggr': non-aggressive, 'both': both aggressive and non-aggressive
     denIdx:     Indices of the components that should be regressed out
 
     Output (within the requested output directory)

--- a/ICA_AROMA_functions.py
+++ b/ICA_AROMA_functions.py
@@ -157,14 +157,14 @@ def register2MNI(fslDir, inFile, outFile, affmat, warp):
 
     # If the no affmat- or warp-file has been specified, assume that the data is already in MNI152 space. In that case only check if resampling to 2mm is needed
     if (len(affmat) == 0) and (len(warp) == 0):
-        # Get 3D voxel size
+        # Get 3D voxel size & bounding box
         pixdim1 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim1 | awk \'{print $2}\'' % (fslDir, inFile)))
         pixdim2 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim2 | awk \'{print $2}\'' % (fslDir, inFile)))
         pixdim3 = float(subprocess.getoutput('%sfslinfo %s | grep pixdim3 | awk \'{print $2}\'' % (fslDir, inFile)))
         dim1 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim1" | awk \'{print $2}\'' % (fslDir, inFile)))
         dim2 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim2" | awk \'{print $2}\'' % (fslDir, inFile)))
         dim3 = float(subprocess.getoutput('%sfslinfo %s | grep "^dim3" | awk \'{print $2}\'' % (fslDir, inFile)))
-        # If voxel size is not 2mm isotropic, resample the data, otherwise copy the file
+        # Check if data is 2mm isotropic voxel size and check that the bounding box dimensions match, if they don't then resample the data 
         if (pixdim1 != 2) or (pixdim2 != 2) or (pixdim3 != 2) or (dim1 != 91) or (dim2 != 109) or (dim3 != 91) :
             os.system(' '.join([os.path.join(fslDir, 'flirt'),
                                 ' -ref ' + ref,


### PR DESCRIPTION
This pull request also addresses issue #16 
When using 2mm voxel size data, the code would not check the image dimensions and just copy the file. This would lead to issues if the image bounding box was not the same size (91x109x91). I added in a dim check along with the pixdim check to fix this and resample if the data is either not 2mm isotropic voxel OR if it is not the same image dimensions.  